### PR TITLE
Added support for non-default connection

### DIFF
--- a/src/InsertOnDuplicateKey.php
+++ b/src/InsertOnDuplicateKey.php
@@ -35,7 +35,7 @@ trait InsertOnDuplicateKey
 
         $data = static::inLineArray($data);
 
-        return DB::statement($sql, $data);
+        return DB::connection(static::getModelConnectionName())->statement($sql, $data);
     }
 
     /**
@@ -60,7 +60,7 @@ trait InsertOnDuplicateKey
 
         $data = static::inLineArray($data);
 
-        return DB::statement($sql, $data);
+        return DB::connection(static::getModelConnectionName())->statement($sql, $data);
     }
 
     /**
@@ -85,7 +85,7 @@ trait InsertOnDuplicateKey
 
         $data = static::inLineArray($data);
 
-        return DB::statement($sql, $data);
+        return DB::connection(static::getModelConnectionName())->statement($sql, $data);
     }
 
     /**
@@ -98,6 +98,17 @@ trait InsertOnDuplicateKey
         $class = get_called_class();
 
         return (new $class())->getTable();
+    }
+
+    /**
+    * Static function for getting connection name
+    *
+    * @return string
+    */
+    public static function getModelConnectionName()
+    {
+        $class = get_called_class();
+        return (new $class())->getConnectionName();
     }
 
     /**


### PR DESCRIPTION
Currently the trait will always use the default database connection when making queries, this causes issues if the user has overridden the connection for the model they are using the trait with (see example of overriding connection used [here](https://www.laravel.com/docs/5.3/eloquent#eloquent-model-conventions)).

This pull request adds a connection name getter and changes all the `DB::statement` queries to `DB::connection->statement`. Queries will default to the default DB connection if the model doesn't specify an alternate connection and will use the models connection if it is specified.
