### PR TITLE
Add support for non-binding values (such as mysql functions)

### DIFF
--- a/src/InsertOnDuplicateKey.php
+++ b/src/InsertOnDuplicateKey.php
@@ -148,7 +148,7 @@ trait InsertOnDuplicateKey
             $questions = [];
             foreach ($row as $key => $value) {
                 if (in_array($key, $dontEscapeColumns)) {
-                    $questions[] = is_a($value, Expression::class) ? $value->__toString() : $value;
+                    $questions[] = $value;
                 } else {
                     $questions[] = '?';
                 }
@@ -257,6 +257,12 @@ trait InsertOnDuplicateKey
 
         $sql  = 'INSERT INTO `' . static::getTablePrefix() . static::getTableName() . '`(' . static::getColumnList($first) . ') VALUES' . PHP_EOL;
         $sql .=  static::buildQuestionMarks($data, $dontEscapeColumns) . PHP_EOL;
+
+        $connection = config('database.default');
+        if ($connection !== 'mysql') {
+            return $sql;
+        }
+
         $sql .= 'ON DUPLICATE KEY UPDATE ';
 
         if (empty($updateColumns)) {

--- a/tests/MainTest.php
+++ b/tests/MainTest.php
@@ -144,6 +144,21 @@ ON DUPLICATE KEY UPDATE `id` = VALUES(`id`), `email` = VALUES(`email`), `name` =
         $this->assertEquals($expected, $result);
     }
 
+    public function testBuildInsertOnDuplicateSqlWithExclusionSimple()
+    {
+        $data = [
+            ['id' => 1, 'email' => 'user1@email.com', 'name' => 'User One']
+        ];
+
+        $expected = 'INSERT INTO `prefix_test_user_table`(`id`,`email`,`name`) VALUES
+(1,?,?)
+ON DUPLICATE KEY UPDATE `id` = VALUES(`id`), `email` = VALUES(`email`), `name` = VALUES(`name`)';
+
+        $result = $this->invokeMethod($this->user, 'buildInsertOnDuplicateSql', [$data,null,['id']]);
+
+        $this->assertEquals($expected, $result);
+    }
+
     public function testBuildInsertOnDuplicateSqlMultiple()
     {
         $data = $this->getDataForInsert();
@@ -153,6 +168,19 @@ ON DUPLICATE KEY UPDATE `id` = VALUES(`id`), `email` = VALUES(`email`), `name` =
 ON DUPLICATE KEY UPDATE `id` = VALUES(`id`), `email` = VALUES(`email`), `name` = VALUES(`name`)';
 
         $result = $this->invokeMethod($this->user, 'buildInsertOnDuplicateSql', [$data]);
+
+        $this->assertEquals($expected, $result);
+    }
+
+    public function testBuildInsertOnDuplicateSqlWithExclusionMultiple()
+    {
+        $data = $this->getDataForInsert();
+
+        $expected = 'INSERT INTO `prefix_test_user_table`(`id`,`email`,`name`) VALUES
+(1,?,?), (2,?,?), (3,?,?)
+ON DUPLICATE KEY UPDATE `id` = VALUES(`id`), `email` = VALUES(`email`), `name` = VALUES(`name`)';
+
+        $result = $this->invokeMethod($this->user, 'buildInsertOnDuplicateSql', [$data,null,['id']]);
 
         $this->assertEquals($expected, $result);
     }


### PR DESCRIPTION
I needed support for insert/updating rows while using mysql builtin functions (ie. AES_ENCRYPT()), but this was sending them to the underlying PDO instance as bindings, which would then insert the mysql function as a string instead of the computed value.

I added a $dontEscapeColumns to the insertOnDuplicateKey function - if provided, it will not try to bind those columns, and will instead pass the raw values to the query.

I have added test coverage, and all existing tests pass